### PR TITLE
Establish peer idenitity by public key

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -99,6 +99,7 @@ dependencies {
     compile "org.jetbrains.anko:anko-appcompat-v7:0.10.4"
     compile "org.jetbrains.anko:anko-cardview-v7:0.10.4"
     compile "org.jetbrains.anko:anko-recyclerview-v7:0.10.4"
+    compile "org.jetbrains.anko:anko-commons:0.10.4"
 }
 repositories {
     mavenCentral()

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -35,15 +35,9 @@
         <!-- Home screen -->
         <activity
             android:name="nl.tudelft.cs4160.identitychain.main.MainActivity"
-            android:windowSoftInputMode="stateUnchanged">
+            android:windowSoftInputMode="adjustNothing">
         </activity>
         <activity android:name="nl.tudelft.cs4160.identitychain.chainExplorer.ChainExplorerActivity" />
-        <activity
-            android:name="nl.tudelft.cs4160.identitychain.modals.BiometricAuthenticationFragment"
-            android:theme="@style/AppTheme.NoActionBar"/>
-
-        <!-- MODALS -->
-        PeerConnectActivity
 
         <!-- DEBUG -->
         <activity

--- a/app/src/main/java/nl/tudelft/cs4160/identitychain/Peer.java
+++ b/app/src/main/java/nl/tudelft/cs4160/identitychain/Peer.java
@@ -1,49 +1,6 @@
 package nl.tudelft.cs4160.identitychain;
 
 public class Peer {
-    private byte[] publicKey;
-    private String ipAddress;
-    private int port;
-
-    public Peer(byte[] pubKey, String ip, int port) {
-        this.publicKey = pubKey;
-        this.ipAddress = ip;
-        this.port = port;
-
-    }
-
-    public byte[] getPublicKey() {
-        return publicKey;
-    }
-
-    public String getIpAddress() {
-        return ipAddress;
-    }
-
-    public int getPort() {
-        return port;
-    }
-
-
-    public void setPublicKey(byte[] publicKey) {
-        this.publicKey = publicKey;
-    }
-
-    public void setIpAddress(String ipAddress) {
-        this.ipAddress = ipAddress;
-    }
-
-    public void setPort(int port) {
-        this.port = port;
-    }
-
-
-    public String toString() {
-        String res = "<Peer: [";
-        res += publicKey + ":" + port + ",PubKey: " + bytesToHex(publicKey) + "]>";
-        return res;
-    }
-
     private final static char[] hexArray = "0123456789ABCDEF".toCharArray();
 
     public static String bytesToHex(byte[] bytes) {

--- a/app/src/main/java/nl/tudelft/cs4160/identitychain/attestation/AttestationFragment.kt
+++ b/app/src/main/java/nl/tudelft/cs4160/identitychain/attestation/AttestationFragment.kt
@@ -81,7 +81,7 @@ class AttestationAdapter(data: OrderedRealmCollection<AttestationRequest>, updat
                         textView("Requestor:").lparams {
                             rightPadding = dip(16)
                         }
-                       nameTextView = textView()
+                        nameTextView = textView()
 
                     }
                     textView("Attestation") {
@@ -116,9 +116,9 @@ class AttestationAdapter(data: OrderedRealmCollection<AttestationRequest>, updat
     override fun onBindViewHolder(holder: AttestationViewHolder, position: Int) {
         val item = getItem(position)
 
-        if(item != null) {
+        if (item != null) {
             val keyAsText = Peer.bytesToHex(item.publicKey())
-            holder.name.text = nameForContact(realm, item.publicKey()) ?: "Unknown peer"
+            holder.name.text = item.publicKey()?.let { nameForContact(realm, it) } ?: "Unknown peer"
 
             holder.publicKey.text = keyAsText.take(20)
 

--- a/app/src/main/java/nl/tudelft/cs4160/identitychain/attestation/AttestationFragment.kt
+++ b/app/src/main/java/nl/tudelft/cs4160/identitychain/attestation/AttestationFragment.kt
@@ -77,18 +77,18 @@ class AttestationAdapter(data: OrderedRealmCollection<AttestationRequest>, updat
                 }
 
                 verticalLayout {
-                    linearLayout {
-                        textView("Requestor:").lparams {
-                            rightPadding = dip(16)
-                        }
-                        nameTextView = textView()
-
-                    }
                     textView("Attestation") {
                         typeface = Typeface.DEFAULT_BOLD
                     }
-                    textView("Age greater than 18")
 
+                    linearLayout {
+                        textView("From:").lparams {
+                            rightMargin = dip(2)
+                        }
+                        nameTextView = textView()
+                    }
+
+                    textView("Age greater than 18")
                     publicKeyTextView = textView()
                 }
 

--- a/app/src/main/java/nl/tudelft/cs4160/identitychain/attestation/AttestationFragment.kt
+++ b/app/src/main/java/nl/tudelft/cs4160/identitychain/attestation/AttestationFragment.kt
@@ -22,6 +22,7 @@ import nl.tudelft.cs4160.identitychain.Peer
 import nl.tudelft.cs4160.identitychain.R
 import nl.tudelft.cs4160.identitychain.database.AttestationRequest
 import nl.tudelft.cs4160.identitychain.main.MainViewModel
+import nl.tudelft.cs4160.identitychain.peers.nameForContact
 import org.jetbrains.anko.*
 import org.jetbrains.anko.cardview.v7.cardView
 import org.jetbrains.anko.recyclerview.v7.recyclerView
@@ -68,6 +69,7 @@ class AttestationAdapter(data: OrderedRealmCollection<AttestationRequest>, updat
         var publicKeyTextView: TextView by Delegates.notNull()
         var rejectButton: ImageButton by Delegates.notNull()
         var verifyAttestationButton: ImageButton by Delegates.notNull()
+        var nameTextView: TextView by Delegates.notNull()
         val view = with(parent.context) {
             cardView {
                 lparams(width = matchParent) {
@@ -75,6 +77,13 @@ class AttestationAdapter(data: OrderedRealmCollection<AttestationRequest>, updat
                 }
 
                 verticalLayout {
+                    linearLayout {
+                        textView("Requestor:").lparams {
+                            rightPadding = dip(16)
+                        }
+                       nameTextView = textView()
+
+                    }
                     textView("Attestation") {
                         typeface = Typeface.DEFAULT_BOLD
                     }
@@ -92,7 +101,7 @@ class AttestationAdapter(data: OrderedRealmCollection<AttestationRequest>, updat
             }
         }
 
-        return AttestationViewHolder(view, publicKeyTextView, rejectButton, verifyAttestationButton)
+        return AttestationViewHolder(view, publicKeyTextView, rejectButton, verifyAttestationButton, nameTextView)
     }
 
     private fun @AnkoViewDslMarker _LinearLayout.confirmationButton(imageSize: Int, resource: Int): ImageButton {
@@ -106,29 +115,38 @@ class AttestationAdapter(data: OrderedRealmCollection<AttestationRequest>, updat
 
     override fun onBindViewHolder(holder: AttestationViewHolder, position: Int) {
         val item = getItem(position)
-        val keyAsText = item?.publicKey()?.let(Peer::bytesToHex) ?: ""
-        holder.publicKey.text = keyAsText.take(20)
-        holder.rejectButton.setOnClickListener {
-            realm.executeTransaction {
-                //the position in the argument can become out to date if items in the middle of the list are removed
-                //then this view holder doesn't rebind and the position become bullshit
-                val upToDatePosition = holder.adapterPosition
-                Log.i(TAG, "deleteting at position $upToDatePosition")
-                Log.i(TAG, "data has length: ${data?.size}")
 
-                if (upToDatePosition != -1) {
-                    data?.deleteFromRealm(upToDatePosition)
+        if(item != null) {
+            val keyAsText = Peer.bytesToHex(item.publicKey())
+            holder.name.text = nameForContact(realm, item.publicKey()) ?: "Unknown peer"
+
+            holder.publicKey.text = keyAsText.take(20)
+
+            holder.rejectButton.setOnClickListener {
+                realm.executeTransaction {
+                    //the position in the argument can become out to date if items in the middle of the list are removed
+                    //then this view holder doesn't rebind and the position become bullshit
+                    val upToDatePosition = holder.adapterPosition
+                    Log.i(TAG, "deleteting at position $upToDatePosition")
+                    Log.i(TAG, "data has length: ${data?.size}")
+
+                    if (upToDatePosition != -1) {
+                        data?.deleteFromRealm(upToDatePosition)
+                    }
                 }
             }
-        }
 
-        holder.verifyAttestationButton.setOnClickListener {
-            val attestationRequest = getItem(holder.adapterPosition)
-            attestationRequest?.let(viewModel::startVerificationAndSigning)
+            holder.verifyAttestationButton.setOnClickListener {
+                val attestationRequest = getItem(holder.adapterPosition)
+                attestationRequest?.let(viewModel::startVerificationAndSigning)
+            }
         }
     }
 
 }
 
-class AttestationViewHolder(view: View, val publicKey: TextView, val rejectButton: ImageButton, val verifyAttestationButton: ImageButton) : RecyclerView.ViewHolder(view)
+class AttestationViewHolder(view: View, val publicKey: TextView, val rejectButton: ImageButton,
+                            val verifyAttestationButton: ImageButton, val name: TextView) : RecyclerView.ViewHolder(view)
+
+
 

--- a/app/src/main/java/nl/tudelft/cs4160/identitychain/chainExplorer/ChainExplorerAdapter.kt
+++ b/app/src/main/java/nl/tudelft/cs4160/identitychain/chainExplorer/ChainExplorerAdapter.kt
@@ -36,7 +36,7 @@ class ChainExplorerAdapter(internal var blocksList: List<MessageProto.TrustChain
 
 
     /**
-     * Puts the data from a TrustChainBlock object into the peer textview.
+     * Puts the data from a TrustChainBlock object into the peer name.
      *
      * @param position
      * @param convertView

--- a/app/src/main/java/nl/tudelft/cs4160/identitychain/database/AttestationRequestRepository.kt
+++ b/app/src/main/java/nl/tudelft/cs4160/identitychain/database/AttestationRequestRepository.kt
@@ -40,9 +40,9 @@ class FakeRepository : AttestationRequestRepository {
 
 open class AttestationRequest : RealmObject() {
     var block: ByteArray = ByteArray(0)
-    var peer: Peer? = Peer()
+    var peer: Peer = Peer()
 
-    fun publicKey() = peer?.publicKey
+    fun publicKey() = peer.publicKey
 
     companion object {
         fun fromHalfBlock(block: ChainService.PeerTrustChainBlock): AttestationRequest {

--- a/app/src/main/java/nl/tudelft/cs4160/identitychain/database/AttestationRequestRepository.kt
+++ b/app/src/main/java/nl/tudelft/cs4160/identitychain/database/AttestationRequestRepository.kt
@@ -40,9 +40,9 @@ class FakeRepository : AttestationRequestRepository {
 
 open class AttestationRequest : RealmObject() {
     var block: ByteArray = ByteArray(0)
-    var peer: Peer = Peer()
+    var peer: Peer? = Peer()
 
-    fun publicKey() = peer.publicKey
+    fun publicKey() = peer?.publicKey
 
     companion object {
         fun fromHalfBlock(block: ChainService.PeerTrustChainBlock): AttestationRequest {

--- a/app/src/main/java/nl/tudelft/cs4160/identitychain/grpc/ChainClientRegistry.kt
+++ b/app/src/main/java/nl/tudelft/cs4160/identitychain/grpc/ChainClientRegistry.kt
@@ -3,14 +3,15 @@ package nl.tudelft.cs4160.identitychain.grpc
 import io.grpc.ManagedChannelBuilder
 import nl.tudelft.cs4160.identitychain.message.ChainGrpc
 import nl.tudelft.cs4160.identitychain.message.ChainService
+import nl.tudelft.cs4160.identitychain.peers.PeerConnectionInformation
 import java.util.concurrent.ConcurrentHashMap
 
 class ChainClientRegistry {
-    private val registryAsync: ConcurrentHashMap<ChainService.Peer, ChainGrpc.ChainFutureStub> = ConcurrentHashMap()
-    fun findStub(peer: ChainService.Peer) = registryAsync.getOrPut(peer) { channelForPeer(peer) }
+    private val registryAsync: ConcurrentHashMap<PeerConnectionInformation, ChainGrpc.ChainFutureStub> = ConcurrentHashMap()
+    fun findStub(peer: PeerConnectionInformation) = registryAsync.getOrPut(peer) { channelForPeer(peer) }
 
-    private fun channelForPeer(peer: ChainService.Peer): ChainGrpc.ChainFutureStub {
-        val channel = ManagedChannelBuilder.forAddress(peer.hostname, peer.port).usePlaintext(true).build();
+    private fun channelForPeer(peer: PeerConnectionInformation): ChainGrpc.ChainFutureStub {
+        val channel = ManagedChannelBuilder.forAddress(peer.host, peer.port).usePlaintext(true).build();
         return ChainGrpc.newFutureStub(channel)
     }
 

--- a/app/src/main/java/nl/tudelft/cs4160/identitychain/grpc/ChainServiceServer.kt
+++ b/app/src/main/java/nl/tudelft/cs4160/identitychain/grpc/ChainServiceServer.kt
@@ -21,6 +21,7 @@ import nl.tudelft.cs4160.identitychain.message.ChainService
 import nl.tudelft.cs4160.identitychain.message.MessageProto
 import nl.tudelft.cs4160.identitychain.database.AttestationRequestRepository
 import nl.tudelft.cs4160.identitychain.peers.*
+import java.security.Key
 import java.security.KeyPair
 import java.util.*
 
@@ -69,6 +70,7 @@ class ChainServiceServer(val storage: TrustChainStorage, val me: ChainService.Pe
     fun keyForPeer(peer: DiscoveredPeer): Single<KeyedPeer> = this.registry.findStub(peer.connectionInformation)
             .getPublicKey(empty).guavaAsSingle(Schedulers.computation())
             .map { addKeyToPeer(peer, it.publicKey.toByteArray()) }
+            .onErrorResumeNext { Single.never<KeyedPeer>() }
 
 
     override fun getPublicKey(request: ChainService.Empty, responseObserver: StreamObserver<ChainService.Key>) {

--- a/app/src/main/java/nl/tudelft/cs4160/identitychain/grpc/ChainServiceServer.kt
+++ b/app/src/main/java/nl/tudelft/cs4160/identitychain/grpc/ChainServiceServer.kt
@@ -19,8 +19,8 @@ import nl.tudelft.cs4160.identitychain.database.TrustChainStorage
 import nl.tudelft.cs4160.identitychain.message.ChainGrpc
 import nl.tudelft.cs4160.identitychain.message.ChainService
 import nl.tudelft.cs4160.identitychain.message.MessageProto
-import nl.tudelft.cs4160.identitychain.network.PeerItem
 import nl.tudelft.cs4160.identitychain.database.AttestationRequestRepository
+import nl.tudelft.cs4160.identitychain.peers.*
 import java.security.KeyPair
 import java.util.*
 
@@ -42,7 +42,7 @@ class ChainServiceServer(val storage: TrustChainStorage, val me: ChainService.Pe
             return
         }
 
-        val peer = request.peer
+        val peer = request.peer.toPeerConnectionInformation()
         val block = request.block
         // check if block matches up with its previous block
         // At this point gaps cannot be tolerated. If we detect a gap we send crawl requests to fill
@@ -65,6 +65,10 @@ class ChainServiceServer(val storage: TrustChainStorage, val me: ChainService.Pe
     }
 
     class GapInChainException : Exception()
+
+    fun keyForPeer(peer: DiscoveredPeer): Single<KeyedPeer> = this.registry.findStub(peer.connectionInformation)
+            .getPublicKey(empty).guavaAsSingle(Schedulers.computation())
+            .map { addKeyToPeer(peer, it.publicKey.toByteArray()) }
 
 
     override fun getPublicKey(request: ChainService.Empty, responseObserver: StreamObserver<ChainService.Key>) {
@@ -110,7 +114,7 @@ class ChainServiceServer(val storage: TrustChainStorage, val me: ChainService.Pe
                     .setT(challenge.t.asByteString())
                     .build()
 
-            registry.findStub(peer).answerChallenge(challengeMessage).guavaAsSingle(Schedulers.io()).map {
+            registry.findStub(peer.toPeerConnectionInformation()).answerChallenge(challengeMessage).guavaAsSingle(Schedulers.io()).map {
                 val challengeReply = it.asZkp()(challenge.s, challenge.t)
                 rangeProofVerifier.interactiveVerify(publicResult, challengeReply)
             }
@@ -173,7 +177,7 @@ class ChainServiceServer(val storage: TrustChainStorage, val me: ChainService.Pe
             if (zkpValid) {
                 Log.i(TAG, "verification successful")
                 signerValidator.signBlock(peer, block)?.let {
-                    registry.findStub(peer).sendSignedBlock(addPeerToBlock(it)).guavaAsSingle(Schedulers.computation()).map { zkpValid }
+                    registry.findStub(peer.toPeerConnectionInformation()).sendSignedBlock(addPeerToBlock(it)).guavaAsSingle(Schedulers.computation()).map { zkpValid }
                 } ?: Single.error<Boolean>(RuntimeException("problems signing the block"))
             } else {
                 Log.i(TAG, "verification failed")
@@ -182,21 +186,19 @@ class ChainServiceServer(val storage: TrustChainStorage, val me: ChainService.Pe
         }
     }
 
-    fun crawlPeer(peer: PeerItem): Single<ChainService.CrawlResponse> {
-        val connectablePeer = peer.asPeerMessage()
-        return sendCrawlRequest(connectablePeer, myPublicKey, -5)
+    fun crawlPeer(peer: PeerConnectionInformation): Single<ChainService.CrawlResponse> {
+        return sendCrawlRequest(peer, myPublicKey, -5)
     }
 
-    fun sendBlockToKnownPeer(peer: PeerItem, payload: String): Single<ChainService.Empty> =
+    fun sendBlockToKnownPeer(peer: PeerConnectionInformation, payload: String): Single<ChainService.Empty> =
             sendBlockToKnownPeer(peer, payload.toByteArray(charset("UTF-8")))
 
-    fun sendBlockToKnownPeer(peer: PeerItem, payload: ByteArray): Single<ChainService.Empty> {
+    fun sendBlockToKnownPeer(peer: PeerConnectionInformation, payload: ByteArray): Single<ChainService.Empty> {
         val sequenceNumberForCrawl = sequenceNumberForCrawl(-5)
         val crawledBlocks = storage.crawl(myPublicKey, sequenceNumberForCrawl)
 
         val crawlResponse = ChainService.CrawlResponse.newBuilder().setPeer(me).addAllBlock(crawledBlocks).build()
-        val peerMessage = peer.asPeerMessage()
-        val peerChannel = registry.findStub(peerMessage)
+        val peerChannel = registry.findStub(peer)
         val keySingle: Single<ChainService.Key> = peerChannel.sendLatestBlocks(crawlResponse).guavaAsSingle(Schedulers.computation())
 
         return keySingle.flatMap { theirPublicKey ->
@@ -212,7 +214,7 @@ class ChainServiceServer(val storage: TrustChainStorage, val me: ChainService.Pe
         }
     }
 
-    fun sendCrawlRequest(peer: ChainService.Peer, publicKey: ByteArray, seqNum: Int): Single<ChainService.CrawlResponse> {
+    fun sendCrawlRequest(peer: PeerConnectionInformation, publicKey: ByteArray, seqNum: Int): Single<ChainService.CrawlResponse> {
         var sq = seqNum
         if (seqNum == 0) {
             sq = storage.getBlock(publicKey,
@@ -233,7 +235,8 @@ class ChainServiceServer(val storage: TrustChainStorage, val me: ChainService.Pe
         // send the crawl request
         val message = ChainService.PeerCrawlRequest.newBuilder().setPeer(me).setRequest(crawlRequest).build()
         //TODO find a better spot for this.
-        return registry.findStub(peer).sendCrawlRequest(message).guavaAsSingle(Schedulers.computation()).doOnSuccess { crawlResponse -> crawlResponse.blockList.forEach { signerValidator.saveCompleteBlock(crawlResponse.peer, it) } }
+        return registry.findStub(peer).sendCrawlRequest(message).guavaAsSingle(Schedulers.computation())
+                .doOnSuccess { crawlResponse -> crawlResponse.blockList.forEach { signerValidator.saveCompleteBlock(crawlResponse.peer, it) } }
     }
 
     override fun sendCrawlRequest(crawlRequest: ChainService.PeerCrawlRequest, responseObserver: StreamObserver<ChainService.CrawlResponse>) {

--- a/app/src/main/java/nl/tudelft/cs4160/identitychain/main/PeerConnectFragment.kt
+++ b/app/src/main/java/nl/tudelft/cs4160/identitychain/main/PeerConnectFragment.kt
@@ -16,10 +16,12 @@ import io.reactivex.Single
 import io.reactivex.disposables.CompositeDisposable
 import io.realm.Realm
 import kotlinx.android.synthetic.main.peer_connect_fragment.view.*
+import nl.tudelft.cs4160.identitychain.Peer
 import nl.tudelft.cs4160.identitychain.R
 import nl.tudelft.cs4160.identitychain.network.PeerViewRecyclerAdapter
 import nl.tudelft.cs4160.identitychain.peers.KeyedPeer
 import nl.tudelft.cs4160.identitychain.peers.PeerContact
+import nl.tudelft.cs4160.identitychain.peers.nameForContact
 import org.jetbrains.anko.customView
 import org.jetbrains.anko.editText
 import org.jetbrains.anko.noButton
@@ -91,9 +93,7 @@ class PeerConnectViewModel : ViewModel() {
         }
     }
 
-    fun nameForPublicKey(publicKey: ByteArray): String? = realm.where(PeerContact::class.java)
-            .equalTo("pk", publicKey)
-            .findFirst()?.name
+    fun nameForPublicKey(publicKey: ByteArray): String? = nameForContact(realm, publicKey)
 
     override fun onCleared() {
         realm.close()

--- a/app/src/main/java/nl/tudelft/cs4160/identitychain/main/PeerConnectFragment.kt
+++ b/app/src/main/java/nl/tudelft/cs4160/identitychain/main/PeerConnectFragment.kt
@@ -91,6 +91,10 @@ class PeerConnectViewModel : ViewModel() {
         }
     }
 
+    fun nameForPublicKey(publicKey: ByteArray): String? = realm.where(PeerContact::class.java)
+            .equalTo("pk", publicKey)
+            .findFirst()?.name
+
     override fun onCleared() {
         realm.close()
     }

--- a/app/src/main/java/nl/tudelft/cs4160/identitychain/main/PeerConnectFragment.kt
+++ b/app/src/main/java/nl/tudelft/cs4160/identitychain/main/PeerConnectFragment.kt
@@ -4,10 +4,14 @@ import android.arch.lifecycle.Observer
 import android.arch.lifecycle.ViewModelProviders
 import android.os.Bundle
 import android.support.v4.app.Fragment
+import android.support.v7.app.AlertDialog
 import android.support.v7.widget.LinearLayoutManager
+import android.text.InputType
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.EditText
+import io.reactivex.Single
 import io.reactivex.disposables.CompositeDisposable
 import kotlinx.android.synthetic.main.peer_connect_fragment.view.*
 import nl.tudelft.cs4160.identitychain.R
@@ -24,7 +28,7 @@ class PeerConnectFragment : Fragment() {
 
         val view = inflater.inflate(R.layout.peer_connect_fragment, parent, false)
         view.discoveryList.layoutManager = LinearLayoutManager(view.context)
-        val peerViewRecyclerAdapter = PeerViewRecyclerAdapter()
+        val peerViewRecyclerAdapter = PeerViewRecyclerAdapter(createNameDialog())
         view.discoveryList.adapter = peerViewRecyclerAdapter
 
         viewModel = ViewModelProviders.of(activity).get(MainViewModel::class.java)
@@ -37,6 +41,26 @@ class PeerConnectFragment : Fragment() {
         disposables.add(disposable)
 
         return view
+    }
+
+    fun createNameDialog(): Single<String> {
+        return Single.create<String> {
+            val input = EditText(this.activity)
+            input.inputType = InputType.TYPE_CLASS_TEXT
+
+
+            AlertDialog.Builder(this.activity)
+                    .setTitle("Enter contact id")
+                    .setMessage("hi")
+//                    .setView(input)
+//                    .setPositiveButton("Name Key")  { _, _ ->
+//                        it.onSuccess(input.text.toString())
+//                    }
+//                    .setNegativeButton("Cancel") {dialog, _ ->
+//                        dialog.cancel()
+//                        it.onError(RuntimeException("Cancel"))}
+                    .show()
+        }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/nl/tudelft/cs4160/identitychain/main/PeerConnectFragment.kt
+++ b/app/src/main/java/nl/tudelft/cs4160/identitychain/main/PeerConnectFragment.kt
@@ -17,6 +17,12 @@ import kotlinx.android.synthetic.main.peer_connect_fragment.view.*
 import nl.tudelft.cs4160.identitychain.R
 import nl.tudelft.cs4160.identitychain.network.PeerViewRecyclerAdapter
 import nl.tudelft.cs4160.identitychain.peers.KeyedPeer
+import org.jetbrains.anko.customView
+import org.jetbrains.anko.editText
+import org.jetbrains.anko.noButton
+import org.jetbrains.anko.support.v4.alert
+import org.jetbrains.anko.yesButton
+import kotlin.properties.Delegates
 
 
 class PeerConnectFragment : Fragment() {
@@ -43,24 +49,18 @@ class PeerConnectFragment : Fragment() {
         return view
     }
 
-    fun createNameDialog(): Single<String> {
-        return Single.create<String> {
-            val input = EditText(this.activity)
-            input.inputType = InputType.TYPE_CLASS_TEXT
+    fun createNameDialog(): Single<String> = Single.create<String> { em ->
+        alert("Name this peer") {
+            var name: EditText by Delegates.notNull()
+            customView {
+                name = editText("") {
+                    hint = "name"
+                }
+            }
 
-
-            AlertDialog.Builder(this.activity)
-                    .setTitle("Enter contact id")
-                    .setMessage("hi")
-//                    .setView(input)
-//                    .setPositiveButton("Name Key")  { _, _ ->
-//                        it.onSuccess(input.text.toString())
-//                    }
-//                    .setNegativeButton("Cancel") {dialog, _ ->
-//                        dialog.cancel()
-//                        it.onError(RuntimeException("Cancel"))}
-                    .show()
-        }
+            noButton { em.onError(RuntimeException("cancelled")) }
+            yesButton { em.onSuccess(name.text.toString()) }
+        }.show()
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/nl/tudelft/cs4160/identitychain/main/PeerConnectFragment.kt
+++ b/app/src/main/java/nl/tudelft/cs4160/identitychain/main/PeerConnectFragment.kt
@@ -11,8 +11,8 @@ import android.view.ViewGroup
 import io.reactivex.disposables.CompositeDisposable
 import kotlinx.android.synthetic.main.peer_connect_fragment.view.*
 import nl.tudelft.cs4160.identitychain.R
-import nl.tudelft.cs4160.identitychain.network.PeerItem
 import nl.tudelft.cs4160.identitychain.network.PeerViewRecyclerAdapter
+import nl.tudelft.cs4160.identitychain.peers.KeyedPeer
 
 
 class PeerConnectFragment : Fragment() {
@@ -29,11 +29,11 @@ class PeerConnectFragment : Fragment() {
 
         viewModel = ViewModelProviders.of(activity).get(MainViewModel::class.java)
 
-        viewModel.allPeers.observe(this, Observer<PeerItem> {
+        viewModel.keyedPeers.observe(this, Observer<KeyedPeer> {
             peerViewRecyclerAdapter.addItem(it!!)
         })
 
-        val disposable = peerViewRecyclerAdapter.selection().subscribe({ viewModel.select(it.withPort(8080)) })
+        val disposable = peerViewRecyclerAdapter.selection().subscribe({ viewModel.select(it) })
         disposables.add(disposable)
 
         return view

--- a/app/src/main/java/nl/tudelft/cs4160/identitychain/modals/BiometricAuthenticationFragment.kt
+++ b/app/src/main/java/nl/tudelft/cs4160/identitychain/modals/BiometricAuthenticationFragment.kt
@@ -2,7 +2,6 @@ package nl.tudelft.cs4160.identitychain.modals
 
 import android.app.Application
 import android.app.Dialog
-import android.app.KeyguardManager
 import android.arch.lifecycle.*
 import android.content.res.Resources.Theme
 import android.graphics.Color
@@ -12,7 +11,6 @@ import android.os.Bundle
 import android.os.CancellationSignal
 import android.support.v4.app.DialogFragment
 import android.support.v4.content.res.ResourcesCompat
-import android.support.v4.hardware.fingerprint.FingerprintManagerCompat
 import android.util.Log
 import android.view.*
 import android.widget.RelativeLayout
@@ -106,8 +104,6 @@ class BiometricAuthenticationViewModel(application: Application) : AndroidViewMo
 
     private fun provideTries(authenticationEvents: Flowable<Boolean>) = Flowable.defer {
         var count = 0
-        Log.i("viewmodel", "anyone calling this?")
-
         authenticationEvents.skipWhile {
             val skip = if (count > 4) {
                 false

--- a/app/src/main/java/nl/tudelft/cs4160/identitychain/network/PeerViewRecyclerAdapter.kt
+++ b/app/src/main/java/nl/tudelft/cs4160/identitychain/network/PeerViewRecyclerAdapter.kt
@@ -1,20 +1,28 @@
 package nl.tudelft.cs4160.identitychain.network
 
+import android.content.Context
 import android.graphics.Color
 import android.support.v4.content.ContextCompat
+import android.support.v7.app.AlertDialog
+import android.support.v7.widget.AlertDialogLayout
 import android.support.v7.widget.CardView
 import android.support.v7.widget.RecyclerView
+import android.text.InputType
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.EditText
 import io.reactivex.BackpressureStrategy
+import io.reactivex.Single
 import io.reactivex.subjects.PublishSubject
 import kotlinx.android.synthetic.main.peer_view.view.*
 import nl.tudelft.cs4160.identitychain.Peer
 import nl.tudelft.cs4160.identitychain.R
 import nl.tudelft.cs4160.identitychain.peers.KeyedPeer
+import org.jetbrains.anko.InputConstraints
+import org.jetbrains.anko.editText
 
-class PeerViewRecyclerAdapter : RecyclerView.Adapter<RecyclerViewHolder>() {
+class PeerViewRecyclerAdapter(val nameDialog: Single<String>) : RecyclerView.Adapter<RecyclerViewHolder>() {
     private val peers: MutableList<SelectablePeer> = ArrayList()
     private var previouslySelected: RecyclerViewHolder? = null
     private val clickedItems: PublishSubject<KeyedPeer> = PublishSubject.create()
@@ -40,6 +48,11 @@ class PeerViewRecyclerAdapter : RecyclerView.Adapter<RecyclerViewHolder>() {
             }
             previouslySelected = holder
             clickedItems.onNext(selectedPeer.peer)
+        }
+
+        holder.itemView.setOnLongClickListener {
+            nameDialog.subscribe()
+            true
         }
     }
 

--- a/app/src/main/java/nl/tudelft/cs4160/identitychain/network/PeerViewRecyclerAdapter.kt
+++ b/app/src/main/java/nl/tudelft/cs4160/identitychain/network/PeerViewRecyclerAdapter.kt
@@ -31,7 +31,9 @@ class PeerViewRecyclerAdapter(val nameDialog: Single<String>, val viewModel: Pee
     override fun onBindViewHolder(holder: RecyclerViewHolder, position: Int) {
         val selectedPeer = peers[position]
         val publicKey = selectedPeer.peer.publicKey
-        holder.name.text = displayName(selectedPeer)
+        val contactName = viewModel.nameForPublicKey(publicKey)
+
+        holder.name.text = contactName ?: selectedPeer.peer.name
         holder.publicKey.text = Peer.bytesToHex(publicKey).take(20)
         val view = holder.cardView
         view.setCardBackgroundColor(colorForSelection(selectedPeer, view))
@@ -46,18 +48,19 @@ class PeerViewRecyclerAdapter(val nameDialog: Single<String>, val viewModel: Pee
             clickedItems.onNext(selectedPeer.peer)
         }
 
-        holder.itemView.setOnLongClickListener {
-            nameDialog.subscribe({
-                viewModel.saveName(it, publicKey)
-                holder.name.text = it
-            }, {
-                //on cancel do nothing
-            })
-            true
+        //contact hasn't been named yet
+        if (contactName == null) {
+            holder.itemView.setOnLongClickListener {
+                nameDialog.subscribe({
+                    viewModel.saveName(it, publicKey)
+                    holder.name.text = it
+                }, {
+                    //on cancel do nothing
+                })
+                true
+            }
         }
     }
-
-    private fun displayName(peer: SelectablePeer) = viewModel.nameForPublicKey(peer.peer.publicKey) ?: peer.peer.name
 
 
     private fun colorForSelection(selectedPeer: SelectablePeer, view: CardView): Int {

--- a/app/src/main/java/nl/tudelft/cs4160/identitychain/network/PeerViewRecyclerAdapter.kt
+++ b/app/src/main/java/nl/tudelft/cs4160/identitychain/network/PeerViewRecyclerAdapter.kt
@@ -1,17 +1,12 @@
 package nl.tudelft.cs4160.identitychain.network
 
-import android.content.Context
 import android.graphics.Color
 import android.support.v4.content.ContextCompat
-import android.support.v7.app.AlertDialog
-import android.support.v7.widget.AlertDialogLayout
 import android.support.v7.widget.CardView
 import android.support.v7.widget.RecyclerView
-import android.text.InputType
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.EditText
 import io.reactivex.BackpressureStrategy
 import io.reactivex.Single
 import io.reactivex.subjects.PublishSubject
@@ -19,8 +14,6 @@ import kotlinx.android.synthetic.main.peer_view.view.*
 import nl.tudelft.cs4160.identitychain.Peer
 import nl.tudelft.cs4160.identitychain.R
 import nl.tudelft.cs4160.identitychain.peers.KeyedPeer
-import org.jetbrains.anko.InputConstraints
-import org.jetbrains.anko.editText
 
 class PeerViewRecyclerAdapter(val nameDialog: Single<String>) : RecyclerView.Adapter<RecyclerViewHolder>() {
     private val peers: MutableList<SelectablePeer> = ArrayList()

--- a/app/src/main/java/nl/tudelft/cs4160/identitychain/network/PeerViewRecyclerAdapter.kt
+++ b/app/src/main/java/nl/tudelft/cs4160/identitychain/network/PeerViewRecyclerAdapter.kt
@@ -31,7 +31,7 @@ class PeerViewRecyclerAdapter(val nameDialog: Single<String>, val viewModel: Pee
     override fun onBindViewHolder(holder: RecyclerViewHolder, position: Int) {
         val selectedPeer = peers[position]
         val publicKey = selectedPeer.peer.publicKey
-        holder.name.text = selectedPeer.peer.name
+        holder.name.text = displayName(selectedPeer)
         holder.publicKey.text = Peer.bytesToHex(publicKey).take(20)
         val view = holder.cardView
         view.setCardBackgroundColor(colorForSelection(selectedPeer, view))
@@ -56,6 +56,8 @@ class PeerViewRecyclerAdapter(val nameDialog: Single<String>, val viewModel: Pee
             true
         }
     }
+
+    private fun displayName(peer: SelectablePeer) = viewModel.nameForPublicKey(peer.peer.publicKey) ?: peer.peer.name
 
 
     private fun colorForSelection(selectedPeer: SelectablePeer, view: CardView): Int {
@@ -95,7 +97,6 @@ class RecyclerViewHolder(view: View) : RecyclerView.ViewHolder(view) {
             return Color.TRANSPARENT
         }
     }
-
 }
 
 internal data class SelectablePeer(var selected: Boolean, val peer: KeyedPeer)

--- a/app/src/main/java/nl/tudelft/cs4160/identitychain/network/PeerViewRecyclerAdapter.kt
+++ b/app/src/main/java/nl/tudelft/cs4160/identitychain/network/PeerViewRecyclerAdapter.kt
@@ -9,14 +9,15 @@ import android.view.View
 import android.view.ViewGroup
 import io.reactivex.BackpressureStrategy
 import io.reactivex.subjects.PublishSubject
-import nl.tudelft.cs4160.identitychain.R
 import kotlinx.android.synthetic.main.peer_view.view.*
-import nl.tudelft.cs4160.identitychain.message.ChainService
+import nl.tudelft.cs4160.identitychain.Peer
+import nl.tudelft.cs4160.identitychain.R
+import nl.tudelft.cs4160.identitychain.peers.KeyedPeer
 
 class PeerViewRecyclerAdapter : RecyclerView.Adapter<RecyclerViewHolder>() {
     private val peers: MutableList<SelectablePeer> = ArrayList()
     private var previouslySelected: RecyclerViewHolder? = null
-    private val clickedItems: PublishSubject<PeerItem> = PublishSubject.create()
+    private val clickedItems: PublishSubject<KeyedPeer> = PublishSubject.create()
 
     override fun onCreateViewHolder(parent: ViewGroup?, viewType: Int): RecyclerViewHolder {
         val view = LayoutInflater.from(parent?.context).inflate(R.layout.peer_view, parent, false)
@@ -27,14 +28,14 @@ class PeerViewRecyclerAdapter : RecyclerView.Adapter<RecyclerViewHolder>() {
 
     override fun onBindViewHolder(holder: RecyclerViewHolder, position: Int) {
         val selectedPeer = peers[position]
-        holder.textview.text = selectedPeer.peer.name
+        holder.textview.text = Peer.bytesToHex(selectedPeer.peer.publicKey)
         val view = holder.cardView
         view.setCardBackgroundColor(colorForSelection(selectedPeer, view))
 
         holder.itemView.setOnClickListener {
             previouslySelected?.toggleColorForSelection(peers)
             //if we click the same item twice it should stay disabled
-            if(previouslySelected != holder) {
+            if (previouslySelected != holder) {
                 holder.toggleColorForSelection(peers)
             }
             previouslySelected = holder
@@ -50,7 +51,7 @@ class PeerViewRecyclerAdapter : RecyclerView.Adapter<RecyclerViewHolder>() {
         }
     }
 
-    fun addItem(item: PeerItem) {
+    fun addItem(item: KeyedPeer) {
         peers.add(SelectablePeer(false, item))
         val size = peers.size
 
@@ -81,11 +82,5 @@ class RecyclerViewHolder(view: View) : RecyclerView.ViewHolder(view) {
 
 }
 
-internal data class SelectablePeer(var selected: Boolean, val peer: PeerItem)
+internal data class SelectablePeer(var selected: Boolean, val peer: KeyedPeer)
 
-data class PeerItem(val name: String, val host: String, val port: Int) {
-
-    fun withPort(port: Int) = PeerItem(name, host, port)
-
-    fun asPeerMessage() = ChainService.Peer.newBuilder().setHostname(host).setPort(port).build()
-}

--- a/app/src/main/java/nl/tudelft/cs4160/identitychain/network/ServiceFactory.kt
+++ b/app/src/main/java/nl/tudelft/cs4160/identitychain/network/ServiceFactory.kt
@@ -8,6 +8,7 @@ import io.reactivex.*
 import io.reactivex.disposables.Disposables
 import nl.tudelft.cs4160.identitychain.peers.DiscoveredPeer
 import nl.tudelft.cs4160.identitychain.peers.PeerConnectionInformation
+import java.util.concurrent.ThreadLocalRandom
 
 
 class ServiceFactory(val context: Context) {
@@ -39,6 +40,7 @@ class ServiceFactory(val context: Context) {
         // This is checked and corrected in the RegistrationListener::onServiceRegistered method.
         serviceInfo.serviceName = serviceName
         serviceInfo.serviceType = serviceType
+        serviceInfo.host
         serviceInfo.port = port
 
         nsdManager.registerService(
@@ -49,6 +51,7 @@ class ServiceFactory(val context: Context) {
         return object : NsdManager.RegistrationListener {
 
             override fun onServiceRegistered(NsdServiceInfo: NsdServiceInfo) {
+                Log.i(TAG, "we registered as $NsdServiceInfo")
                 // Update serviceName to deal with conflicts.
                 serviceInfo.serviceName = NsdServiceInfo.serviceName
             }

--- a/app/src/main/java/nl/tudelft/cs4160/identitychain/network/ServiceFactory.kt
+++ b/app/src/main/java/nl/tudelft/cs4160/identitychain/network/ServiceFactory.kt
@@ -2,11 +2,12 @@ package nl.tudelft.cs4160.identitychain.network
 
 import android.content.Context
 import android.net.nsd.NsdServiceInfo
-import java.net.ServerSocket
 import android.net.nsd.NsdManager
 import android.util.Log
 import io.reactivex.*
 import io.reactivex.disposables.Disposables
+import nl.tudelft.cs4160.identitychain.peers.DiscoveredPeer
+import nl.tudelft.cs4160.identitychain.peers.PeerConnectionInformation
 
 
 class ServiceFactory(val context: Context) {
@@ -20,8 +21,8 @@ class ServiceFactory(val context: Context) {
         registerService(port)
     }
 
-    fun startPeerDiscovery(): Flowable<PeerItem> {
-        val create = Flowable.create<PeerItem>({ em ->
+    fun startPeerDiscovery(): Flowable<DiscoveredPeer> {
+        val create = Flowable.create<DiscoveredPeer>({ em ->
             val resolveListener = { initializeResolveListener(em) }
 
             val discoveryListener = initializeDiscoveryListener(resolveListener)
@@ -112,7 +113,7 @@ class ServiceFactory(val context: Context) {
         }
     }
 
-    fun initializeResolveListener(emitter: FlowableEmitter<PeerItem>): NsdManager.ResolveListener {
+    fun initializeResolveListener(emitter: FlowableEmitter<DiscoveredPeer>): NsdManager.ResolveListener {
         return object : NsdManager.ResolveListener {
 
             override fun onResolveFailed(serviceInfo: NsdServiceInfo, errorCode: Int) {
@@ -128,7 +129,7 @@ class ServiceFactory(val context: Context) {
                     return
                 }
 
-                emitter.onNext(PeerItem(info.serviceName, info.host.hostAddress, info.port))
+                emitter.onNext(DiscoveredPeer(PeerConnectionInformation(info.host.hostAddress), info.serviceName))
             }
         }
     }

--- a/app/src/main/java/nl/tudelft/cs4160/identitychain/peers/PeerContact.kt
+++ b/app/src/main/java/nl/tudelft/cs4160/identitychain/peers/PeerContact.kt
@@ -2,7 +2,4 @@ package nl.tudelft.cs4160.identitychain.peers
 
 import io.realm.RealmObject
 
-open class PeerContact : RealmObject() {
-    var name: String = ""
-    var pk: ByteArray = ByteArray(0)
-}
+open class PeerContact(var name: String = "", var pk: ByteArray = ByteArray(0)) : RealmObject()

--- a/app/src/main/java/nl/tudelft/cs4160/identitychain/peers/PeerContact.kt
+++ b/app/src/main/java/nl/tudelft/cs4160/identitychain/peers/PeerContact.kt
@@ -1,5 +1,11 @@
 package nl.tudelft.cs4160.identitychain.peers
 
+import io.realm.Realm
 import io.realm.RealmObject
 
 open class PeerContact(var name: String = "", var pk: ByteArray = ByteArray(0)) : RealmObject()
+
+fun nameForContact(realm: Realm, publicKey: ByteArray) =
+        realm.where(PeerContact::class.java)
+                .equalTo("pk", publicKey)
+                .findFirst()?.name

--- a/app/src/main/java/nl/tudelft/cs4160/identitychain/peers/PeerContact.kt
+++ b/app/src/main/java/nl/tudelft/cs4160/identitychain/peers/PeerContact.kt
@@ -1,0 +1,8 @@
+package nl.tudelft.cs4160.identitychain.peers
+
+import io.realm.RealmObject
+
+open class PeerContact : RealmObject() {
+    var name: String = ""
+    var pk: ByteArray = ByteArray(0)
+}

--- a/app/src/main/java/nl/tudelft/cs4160/identitychain/peers/Peers.kt
+++ b/app/src/main/java/nl/tudelft/cs4160/identitychain/peers/Peers.kt
@@ -11,6 +11,7 @@ import java.util.*
 data class PeerConnectionInformation(val host: String) {
     val port: Int = 8080
 }
+
 fun ChainService.Peer.toPeerConnectionInformation() = PeerConnectionInformation(this.hostname)
 
 /**
@@ -24,7 +25,7 @@ data class DiscoveredPeer(val connectionInformation: PeerConnectionInformation, 
  *
  * The public key is used to persistently represent the identity of the peer.
  */
-class KeyedPeer(val connectionInformation: PeerConnectionInformation, val publicKey: ByteArray) {
+class KeyedPeer(val connectionInformation: PeerConnectionInformation, val publicKey: ByteArray, val name: String) {
     val port: Int = 8080
 
     val host: String
@@ -38,4 +39,4 @@ class KeyedPeer(val connectionInformation: PeerConnectionInformation, val public
 }
 
 
-fun addKeyToPeer(peerItem: DiscoveredPeer, publicKey: ByteArray) = with(peerItem) { KeyedPeer(peerItem.connectionInformation, publicKey) }
+fun addKeyToPeer(peerItem: DiscoveredPeer, publicKey: ByteArray) = with(peerItem) { KeyedPeer(peerItem.connectionInformation, publicKey, peerItem.name) }

--- a/app/src/main/java/nl/tudelft/cs4160/identitychain/peers/Peers.kt
+++ b/app/src/main/java/nl/tudelft/cs4160/identitychain/peers/Peers.kt
@@ -17,14 +17,14 @@ fun ChainService.Peer.toPeerConnectionInformation() = PeerConnectionInformation(
  * A peer that has just been discovered through @see nl.tudelft.cs4160.identitychain.network.ServiceFactory
  * This holds on to the discovery name in case no name has been associated yet.
  */
-class DiscoveredPeer(val connectionInformation: PeerConnectionInformation, val name: String)
+data class DiscoveredPeer(val connectionInformation: PeerConnectionInformation, val name: String)
 
 /**
  * A peer whose public key has been resolved through an rpc request.
  *
  * The public key is used to persistently represent the identity of the peer.
  */
-data class KeyedPeer(val connectionInformation: PeerConnectionInformation, val publicKey: ByteArray) {
+class KeyedPeer(val connectionInformation: PeerConnectionInformation, val publicKey: ByteArray) {
     val port: Int = 8080
 
     val host: String
@@ -35,24 +35,6 @@ data class KeyedPeer(val connectionInformation: PeerConnectionInformation, val p
             .setPort(port)
             .setPublicKey(ByteString.copyFrom(publicKey))
             .build()
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as KeyedPeer
-
-        if (connectionInformation != other.connectionInformation) return false
-        if (!Arrays.equals(publicKey, other.publicKey)) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = connectionInformation.hashCode()
-        result = 31 * result + Arrays.hashCode(publicKey)
-        return result
-    }
 }
 
 

--- a/app/src/main/java/nl/tudelft/cs4160/identitychain/peers/Peers.kt
+++ b/app/src/main/java/nl/tudelft/cs4160/identitychain/peers/Peers.kt
@@ -1,0 +1,59 @@
+package nl.tudelft.cs4160.identitychain.peers
+
+import com.google.protobuf.ByteString
+import nl.tudelft.cs4160.identitychain.message.ChainService
+import java.util.*
+
+/**
+ * The minimal amount of information required to start a grpc connection to a peer.
+ * The port, for now hard coded since every grpc server runs on 8001
+ */
+data class PeerConnectionInformation(val host: String) {
+    val port: Int = 8080
+}
+fun ChainService.Peer.toPeerConnectionInformation() = PeerConnectionInformation(this.hostname)
+
+/**
+ * A peer that has just been discovered through @see nl.tudelft.cs4160.identitychain.network.ServiceFactory
+ * This holds on to the discovery name in case no name has been associated yet.
+ */
+class DiscoveredPeer(val connectionInformation: PeerConnectionInformation, val name: String)
+
+/**
+ * A peer whose public key has been resolved through an rpc request.
+ *
+ * The public key is used to persistently represent the identity of the peer.
+ */
+data class KeyedPeer(val connectionInformation: PeerConnectionInformation, val publicKey: ByteArray) {
+    val port: Int = 8080
+
+    val host: String
+        get() = connectionInformation.host
+
+    fun asPeerMessage() = ChainService.Peer.newBuilder()
+            .setHostname(host)
+            .setPort(port)
+            .setPublicKey(ByteString.copyFrom(publicKey))
+            .build()
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as KeyedPeer
+
+        if (connectionInformation != other.connectionInformation) return false
+        if (!Arrays.equals(publicKey, other.publicKey)) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = connectionInformation.hashCode()
+        result = 31 * result + Arrays.hashCode(publicKey)
+        return result
+    }
+}
+
+
+fun addKeyToPeer(peerItem: DiscoveredPeer, publicKey: ByteArray) = with(peerItem) { KeyedPeer(peerItem.connectionInformation, publicKey) }

--- a/app/src/main/java/nl/tudelft/cs4160/identitychain/peers/Peers.kt
+++ b/app/src/main/java/nl/tudelft/cs4160/identitychain/peers/Peers.kt
@@ -6,7 +6,7 @@ import java.util.*
 
 /**
  * The minimal amount of information required to start a grpc connection to a peer.
- * The port, for now hard coded since every grpc server runs on 8001
+ * The port, for now hard coded since every grpc server runs on 8080
  */
 data class PeerConnectionInformation(val host: String) {
     val port: Int = 8080

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -14,6 +14,7 @@
 
     <android.support.design.widget.BottomNavigationView
         android:layout_width="match_parent"
+        android:isScrollContainer="false"
         android:layout_height="wrap_content"
         android:id="@+id/bottomNavigationBar"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/peer_view.xml
+++ b/app/src/main/res/layout/peer_view.xml
@@ -5,10 +5,24 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content">
 
-    <TextView
-        android:id="@+id/peerName"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:padding="8dp"
-        android:textSize="15sp" />
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/peerName"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="8dp"
+            android:textSize="15sp" />
+
+        <TextView
+            android:id="@+id/publicKey"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="8dp"
+            android:textSize="15sp" />
+    </LinearLayout>
+
 </android.support.v7.widget.CardView>

--- a/app/src/main/res/layout/peer_view.xml
+++ b/app/src/main/res/layout/peer_view.xml
@@ -2,7 +2,7 @@
 
 <android.support.v7.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/peerCardView"
-    android:layout_width="wrap_content"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
     <LinearLayout
@@ -14,14 +14,15 @@
             android:id="@+id/peerName"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:padding="8dp"
-            android:textSize="15sp" />
+            android:paddingTop="4dp"
+            android:textSize="15sp"
+            android:textStyle="bold" />
 
         <TextView
             android:id="@+id/publicKey"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:padding="8dp"
+            android:paddingBottom="4dp"
             android:textSize="15sp" />
     </LinearLayout>
 

--- a/app/src/test/java/nl/tudelft/cs4160/identitychain/grpc/ChainServiceServerTest.kt
+++ b/app/src/test/java/nl/tudelft/cs4160/identitychain/grpc/ChainServiceServerTest.kt
@@ -9,7 +9,7 @@ import nl.tudelft.cs4160.identitychain.block.TrustChainBlock.GENESIS_SEQ
 import nl.tudelft.cs4160.identitychain.database.FakeRepository
 import nl.tudelft.cs4160.identitychain.database.TrustChainMemoryStorage
 import nl.tudelft.cs4160.identitychain.message.ChainService
-import nl.tudelft.cs4160.identitychain.network.PeerItem
+import nl.tudelft.cs4160.identitychain.peers.PeerConnectionInformation
 import org.junit.After
 import org.junit.Assert.*
 import org.junit.Ignore
@@ -22,8 +22,8 @@ class ChainServiceServerTest {
     val testServerOne = peerAndServerForPort(8080)
     val testServerTwo = peerAndServerForPort(8081)
 
-    val serverTwoPeerItem = PeerItem("peerBoy", "localhost", 8081)
-    val serverOnePeerItem = PeerItem("peerBoy", "localhost", 8080)
+    val serverTwoPeerItem = PeerConnectionInformation("peerBoy", "localhost", 8081)
+    val serverOnePeerItem = PeerConnectionInformation("peerBoy", "localhost", 8080)
 
     @Test
     fun initial_crawl_request_should_return_genesis_block() {


### PR DESCRIPTION
Track public keys as a longer lasting identity than the service discovery name.
Should make the demo a whole lot clearer too.

Also it makes the keyboard slide over the bottom navigation bar.
Instead of making the bottom navigation bar shove up weirdly