### PR TITLE
Show the last instead of first 20 digits of the public key

### DIFF
--- a/app/src/main/java/nl/tudelft/cs4160/identitychain/attestation/AttestationFragment.kt
+++ b/app/src/main/java/nl/tudelft/cs4160/identitychain/attestation/AttestationFragment.kt
@@ -120,7 +120,7 @@ class AttestationAdapter(data: OrderedRealmCollection<AttestationRequest>, updat
             val keyAsText = Peer.bytesToHex(item.publicKey())
             holder.name.text = item.publicKey()?.let { nameForContact(realm, it) } ?: "Unknown peer"
 
-            holder.publicKey.text = keyAsText.take(20)
+            holder.publicKey.text = keyAsText.takeLast(20)
 
             holder.rejectButton.setOnClickListener {
                 realm.executeTransaction {

--- a/app/src/main/java/nl/tudelft/cs4160/identitychain/network/PeerViewRecyclerAdapter.kt
+++ b/app/src/main/java/nl/tudelft/cs4160/identitychain/network/PeerViewRecyclerAdapter.kt
@@ -34,7 +34,7 @@ class PeerViewRecyclerAdapter(val nameDialog: Single<String>, val viewModel: Pee
         val contactName = viewModel.nameForPublicKey(publicKey)
 
         holder.name.text = contactName ?: selectedPeer.peer.name
-        holder.publicKey.text = Peer.bytesToHex(publicKey).take(20)
+        holder.publicKey.text = Peer.bytesToHex(publicKey).takeLast(20)
         val view = holder.cardView
         view.setCardBackgroundColor(colorForSelection(selectedPeer, view))
 


### PR DESCRIPTION
The first digits of the public key seem to be always the same.
Therefore, the ```take``` has been changed into ```takeLast``` to display unique characters.